### PR TITLE
Fix compiledb-gen-make when invoked from $PATH

### DIFF
--- a/compiledb-gen-aosp
+++ b/compiledb-gen-aosp
@@ -20,7 +20,7 @@
 #
 set -e
 
-scriptdir=$(cd "$(dirname $(readlink "$0"))" && pwd)
+scriptdir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 make_cmd=${scriptdir}/compiledb-gen-make
 
 VERBOSE=0

--- a/compiledb-gen-make
+++ b/compiledb-gen-make
@@ -20,7 +20,7 @@
 #
 set -e
 
-scriptdir=$(cd "$(dirname $(readlink "$0"))" && pwd)
+scriptdir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 parser_cmd=${scriptdir}/compiledb-gen-parser
 
 show_help() {


### PR DESCRIPTION
The current code has a bug when compiledb-gen-make is run from $PATH, as
the dirname will resolve to ''. The correct solution is to use
"${BASH_SOURCE[0]}" which has the actual path of the script being
invoked, rather than "$0" which just has the invoked name. This also
fixes compiledb-gen-aosp which has the same bug.