### PR TITLE
Fix #13: Use bashlex to preprocess substitution commands

### DIFF
--- a/compiledb/commands/make.py
+++ b/compiledb/commands/make.py
@@ -7,7 +7,7 @@ from compiledb import generate
 
 if version_info[0] >= 3:  # Python 3
     def popen(cmd, encoding='utf-8', **kwargs):
-        return Popen(cmd, **kwargs, encoding=encoding)
+        return Popen(cmd, encoding=encoding, **kwargs)
 else:  # Python 2
     def popen(cmd, encoding='utf-8', **kwargs):
         return Popen(cmd, **kwargs)

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -18,8 +18,20 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+import bashlex.parser
+import bashlex.ast
 import os.path
 import re
+import subprocess
+from sys import version_info
+
+
+if version_info[0] >= 3:  # Python 3
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, encoding=encoding, **kwargs)
+else:  # Python 2
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, **kwargs)
 
 
 class ParsingResult(object):
@@ -39,6 +51,16 @@ class Error(Exception):
 
     def __str__(self):
         return "Error: {}".format(self.msg)
+
+
+class NodeVisitor(bashlex.ast.nodevisitor):
+    def __init__(self, substitutions):
+        self.substitutions = substitutions
+
+    def visitcommandsubstitution(self, n, command):
+        self.substitutions.append(n)
+        # do not recurse into child nodes
+        return False
 
 
 def parse_build_log(build_log, proj_dir, inc_prefix, exclude_list, verbose):
@@ -101,10 +123,37 @@ def parse_build_log(build_log, proj_dir, inc_prefix, exclude_list, verbose):
         if (make_enter_dir.match(line)):
             working_dir = enter_dir.group('dir')
             dir_stack.append(working_dir)
+            continue
         elif (make_leave_dir.match(line)):
             dir_stack.pop()
             working_dir = dir_stack[-1]
+            continue
 
+        # Uses bashlex to parse and process sh/bash
+        # substitution commands
+        trees = bashlex.parser.parse(line)
+        subst_nodes = []
+        for tree in trees:
+            visitor = NodeVisitor(subst_nodes)
+            visitor.visit(tree)
+
+        # do replacements from the end so the indicies will be correct
+        subst_nodes.reverse()
+        postprocessed = list(line)
+
+        for node in subst_nodes:
+            start, end = node.command.pos
+            subst_cmd = line[start:end]
+
+            start, end = node.pos
+            out = run_cmd(subst_cmd, shell=True, encoding='utf-8')
+            postprocessed[start:end] = out.strip()
+
+        line = ''.join(postprocessed)
+        # print('---> {}'.format(line))
+
+        # Extract build command arguments of interest
+        # TODO: Refactor to use bashlex + argparse/optparse
         if (cc_compile_regex.match(line)):
             compiler = 'cc'
         elif (cpp_compile_regex.match(line)):

--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -26,12 +26,40 @@ import subprocess
 from sys import version_info
 
 
-if version_info[0] >= 3:  # Python 3
-    def run_cmd(cmd, encoding='utf-8', **kwargs):
-        return subprocess.check_output(cmd, encoding=encoding, **kwargs)
-else:  # Python 2
-    def run_cmd(cmd, encoding='utf-8', **kwargs):
-        return subprocess.check_output(cmd, **kwargs)
+# Internal variables used to parse build log entries
+# TODO: Most of them will be removed soon in favor of an
+# bashlex/argparse based parsing (mainly for command line options
+# in to avoid reinventing the wheel and eliminate false positives
+# for compiler, wrappers and their flags
+cc_compile_regex = re.compile("(.*-?g?cc )|(.*-?clang )")
+cpp_compile_regex = re.compile("(.*-?[gc]\+\+ )|(.*-?clang\+\+ )")
+file_regex = re.compile("(^.+\.c$)|(^.+\.cc$)|(^.+\.cpp$)|(^.+\.cxx$)")
+
+# Leverage make --print-directory option
+make_enter_dir = re.compile("^\s*make\[\d+\]: Entering directory [`\'\"](?P<dir>.*)[`\'\"]\s*$")
+make_leave_dir = re.compile("^\s*make\[\d+\]: Leaving directory .*$")
+
+# Flags we want:
+# -includes (-i, -I)
+# -warnings (-Werror), but no assembler, etc. flags (-Wa,-option)
+# -language (-std=gnu99) and standard library (-nostdlib)
+# -defines (-D)
+# -m32 -m64
+flag_patterns = [
+    "-c",
+    "-m.+",
+    "-W[^,]*",
+    "-[iIDF].*",
+    "-std=[a-z0-9+]+",
+    "-(no)?std(lib|inc)",
+    "-D([a-zA-Z0-9_]+)=?(.*)",
+    "--sysroot=?.*"
+]
+flags_whitelist = re.compile("|".join(map("^{}$".format, flag_patterns)))
+
+# Used to only bundle filenames with applicable arguments
+filename_flags = ["-o", "-I", "-isystem", "-iquote", "-include", "-imacros", "-isysroot", "--sysroot"]
+invalid_include_regex = re.compile("(^.*out/.+_intermediates.*$)|(.+/proguard.flags$)")
 
 
 class ParsingResult(object):
@@ -66,43 +94,12 @@ class NodeVisitor(bashlex.ast.nodevisitor):
 def parse_build_log(build_log, proj_dir, inc_prefix, exclude_list, verbose):
     result = ParsingResult()
 
-    cc_compile_regex = re.compile("(.*-?g?cc )|(.*-?clang )")
-    cpp_compile_regex = re.compile("(.*-?[gc]\+\+ )|(.*-?clang\+\+ )")
-
-    # Leverage make --print-directory option
-    make_enter_dir = re.compile("^\s*make\[\d+\]: Entering directory [`\'\"](?P<dir>.*)[`\'\"]\s*$")
-    make_leave_dir = re.compile("^\s*make\[\d+\]: Leaving directory .*$")
-
-    # Flags we want:
-    # -includes (-i, -I)
-    # -warnings (-Werror), but no assembler, etc. flags (-Wa,-option)
-    # -language (-std=gnu99) and standard library (-nostdlib)
-    # -defines (-D)
-    # -m32 -m64
-    flags_whitelist = [
-        "-c",
-        "-m.+",
-        "-W[^,]*",
-        "-[iIDF].*",
-        "-std=[a-z0-9+]+",
-        "-(no)?std(lib|inc)",
-        "-D([a-zA-Z0-9_]+)=?(.*)",
-        "--sysroot=?.*"
-    ]
-    flags_whitelist = re.compile("|".join(map("^{}$".format, flags_whitelist)))
-
-    # Used to only bundle filenames with applicable arguments
-    filename_flags = ["-o", "-I", "-isystem", "-iquote", "-include", "-imacros", "-isysroot", "--sysroot"]
-    invalid_include_regex = re.compile("(^.*out/.+_intermediates.*$)|(.+/proguard.flags$)")
-
     exclude_regex = None
     if len(exclude_list) > 0:
         try:
             exclude_regex = re.compile("|".join(exclude_list))
         except:
             raise Error('Regular expression not valid: {}'.format(exclude_list))
-
-    file_regex = re.compile("(^.+\.c$)|(^.+\.cc$)|(^.+\.cpp$)|(^.+\.cxx$)")
 
     compiler = None
     dir_stack = [proj_dir]
@@ -146,7 +143,7 @@ def parse_build_log(build_log, proj_dir, inc_prefix, exclude_list, verbose):
             subst_cmd = line[start:end]
 
             start, end = node.pos
-            out = run_cmd(subst_cmd, shell=True, encoding='utf-8')
+            out = run_cmd(subst_cmd, shell=True, cwd=working_dir)
             postprocessed[start:end] = out.strip()
 
         line = ''.join(postprocessed)
@@ -243,5 +240,13 @@ def unbalanced_quotes(s):
 
 def unescape(s):
     return s.encode().decode('unicode_escape')
+
+
+if version_info[0] >= 3:  # Python 3
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, encoding=encoding, **kwargs)
+else:  # Python 2
+    def run_cmd(cmd, encoding='utf-8', **kwargs):
+        return subprocess.check_output(cmd, **kwargs)
 
 # ex: ts=2 sw=4 et filetype=python

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,7 +1,10 @@
 attrs==18.1.0
+bashlex==0.12
 click==6.7
+enum34==1.1.6
 more-itertools==4.1.0
 pluggy==0.6.0
 py==1.5.3
 pytest==3.5.1
 six==1.11.0
+

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     keywords='compilation-database clang c cpp makefile rtags completion',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
     install_requires=[
-        'click'
+        'click',
+        'bashlex'
     ],
     extras_require={
         'dev': [],

--- a/tests/data/autotools_simple.txt
+++ b/tests/data/autotools_simple.txt
@@ -1,0 +1,1 @@
+gcc -DPACKAGE_NAME=\"hello\" -DPACKAGE_VERSION=\"1.0.0\" -DSTDC_HEADERS=1 -I. -I../../src/libhello -c -o hello_world1-main.o `test -f 'main.c' || echo './'`main.c

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -28,10 +28,33 @@ def test_empty():
     exclude_list = []
     verbose = False
 
-    result = parse_build_log(build_log, proj_dir, incpath_prefix, exclude_list, verbose)
+    result = parse_build_log(build_log, proj_dir, incpath_prefix, exclude_list,
+                             verbose)
     assert result.count == 0
     assert result.skipped == 0
     assert result.compdb is not None
     assert type(result.compdb) == list
     assert len(result.compdb) == 0
 
+
+def test_trivial_build_command():
+    pwd = '/build'
+
+    build_log = ['gcc -o hello.o -c hello.c']
+    result = parse_build_log(
+        build_log,
+        proj_dir=pwd,
+        inc_prefix=None,
+        exclude_list=[],
+        verbose=False)
+
+    assert result.count == 1
+    assert result.skipped == 0
+    assert len(result.compdb) == 1
+    assert result.compdb[0] == {
+        'directory': '/build',
+        'file': 'hello.c',
+        'arguments': [
+            'cc', '-c', 'hello.c'
+        ]
+    }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from os import path
+from os import path, getcwd
 
 from compiledb.parser import parse_build_log
 
@@ -42,8 +42,7 @@ def test_empty():
 
 
 def test_trivial_build_command():
-    pwd = '/build'
-
+    pwd = getcwd()
     build_log = ['gcc -o hello.o -c hello.c']
     result = parse_build_log(
         build_log,
@@ -56,7 +55,7 @@ def test_trivial_build_command():
     assert result.skipped == 0
     assert len(result.compdb) == 1
     assert result.compdb[0] == {
-        'directory': '/build',
+        'directory': pwd,
         'file': 'hello.c',
         'arguments': [
             'cc', '-c', 'hello.c'
@@ -65,7 +64,7 @@ def test_trivial_build_command():
 
 
 def test_automake_command():
-    pwd = '/build'
+    pwd = getcwd()
     with input_file('autotools_simple') as build_log:
         result = parse_build_log(
             build_log,
@@ -78,7 +77,7 @@ def test_automake_command():
     assert result.skipped == 0
     assert len(result.compdb) == 1
     assert result.compdb[0] == {
-        'directory': '/build',
+        'directory': pwd,
         'file': './main.c',
         'arguments': [
             'cc',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,11 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from os import path
+
 from compiledb.parser import parse_build_log
+
+data_dir = path.abspath(path.join(path.dirname(__file__), 'data'))
 
 
 def test_empty():
@@ -58,3 +62,38 @@ def test_trivial_build_command():
             'cc', '-c', 'hello.c'
         ]
     }
+
+
+def test_automake_command():
+    pwd = '/build'
+    with input_file('autotools_simple') as build_log:
+        result = parse_build_log(
+            build_log,
+            proj_dir=pwd,
+            inc_prefix=None,
+            exclude_list=[],
+            verbose=False)
+
+    assert result.count == 1
+    assert result.skipped == 0
+    assert len(result.compdb) == 1
+    assert result.compdb[0] == {
+        'directory': '/build',
+        'file': './main.c',
+        'arguments': [
+            'cc',
+            '-DPACKAGE_NAME="hello"',
+            '-DPACKAGE_VERSION="1.0.0"',
+            '-DSTDC_HEADERS=1',
+            '-I.',
+            '-I../../src/libhello',
+            '-c',
+            './main.c'
+        ]
+    }
+
+
+def input_file(relpath):
+    relpath = '{}.txt'.format(relpath)
+    return open(path.join(data_dir, relpath), 'r')
+

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,7 @@ exclude = tests
 
 [pytest]
 testpaths = tests
-addopts =
-    --cov-report html --cov-report term --junitxml=test-report.xml
-    --cov pyls --cov tests
+addopts = --junitxml=test-report.xml
 
 [testenv]
 commands =


### PR DESCRIPTION
The following command should work as expected:

```compiledb -i sample.txt -o-```

- Output:
```
## Processing build commands from <stdin>
## Writing compilation database with 1 entries to <stdout>
[
 {
  "directory": "/home/nick/projects/compiledb/compiledb-generator",
  "file": "./main.c",
  "arguments": [
   "cc",
   "-DPACKAGE_NAME=\"hello\"",
   "-DPACKAGE_TARNAME=\"hello\"",
   "-DPACKAGE_VERSION=\"1.0.0\"",
   "-DPACKAGE_STRING=\"hello\\ 1.0.0\"",
   "-DPACKAGE_BUGREPORT=\"info@hello.org\"",
   "-DPACKAGE_URL=\"http://www.hello.org\"",
   "-DSTDC_HEADERS=1",
   "-DHAVE_SYS_TYPES_H=1",
   "-DHAVE_SYS_STAT_H=1",
   "-DHAVE_STDLIB_H=1",
   "-DHAVE_STRING_H=1",
   "-DHAVE_MEMORY_H=1",
   "-DHAVE_STRINGS_H=1",
   "-DHAVE_INTTYPES_H=1",
   "-DHAVE_STDINT_H=1",
   "-DHAVE_UNISTD_H=1",
   "-DHAVE_DLFCN_H=1",
   "-DLT_OBJDIR=\".libs/\"",
   "-I-/.",
   "-I-/../../src/libhello",
   "-c",
   "./main.c"
  ]
 }
]
## Done.
```
- sample.txt
```
gcc -DPACKAGE_NAME=\"hello\" -DPACKAGE_TARNAME=\"hello\" -DPACKAGE_VERSION=\"1.0.0\" -DPACKAGE_STRING=\"hello\ 1.0.0\" -DPACKAGE_BUGREPORT=\"info@hello.org\" -DPACKAGE_URL=\"http://www.hello.org\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I. -I../../src/libhello -g -O2 -MT hello_world1-main.o -MD -MP -MF .deps/hello_world1-main.Tpo -c -o hello_world1-main.o `test -f 'main.c' || echo './'`main.c
```

**TODO: There is still an issue with autotools-based builds with the `-B`, which causes `configure` script to be executed for every command.**