### PR TITLE
Include '-f' flags from compiler line

### DIFF
--- a/compiledb/parser.py
+++ b/compiledb/parser.py
@@ -53,7 +53,8 @@ flag_patterns = [
     "-std=[a-z0-9+]+",
     "-(no)?std(lib|inc)",
     "-D([a-zA-Z0-9_]+)=?(.*)",
-    "--sysroot=?.*"
+    "--sysroot=?.*",
+    "-f.*"
 ]
 flags_whitelist = re.compile("|".join(map("^{}$".format, flag_patterns)))
 


### PR DESCRIPTION
I'm not sure why we have a whitelist of flags we want to take from the compiler line, but there's a ton of flags we'll miss without the `-f` family (sanitizers, for instance).

I'd prefer if we just took all flags from the compiler line, but at least this fixes another use case.